### PR TITLE
Add acceptance tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,3 +4,11 @@
 fixtures:
   forge_modules:
      stdlib: "puppetlabs/stdlib"
+     apt: "puppetlabs-apt"
+  repositories:
+    provision: 'https://github.com/puppetlabs/provision.git'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
+    yumrepo_core:
+      repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
+      puppet_version: ">= 4.10.0 < 7.0.0"

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,5 +1,7 @@
 ---
 ".travis.yml":
+  use_litmus: true
+  beaker: true
   deploy_to_forge:
     enabled: false
   secure: ''
@@ -8,16 +10,20 @@
     - master
     - /^v\d/
   simplecov: true
-  includes:
-    - env: PUPPET_GEM_VERSION="~> 4.10" CHECK=parallel_spec
-      rvm: 2.4.5
-      stage: spec
 
 appveyor.yml:
   delete: true
 
 ".gitlab-ci.yml":
   delete: true
+
+Gemfile:
+  optional:
+    ':development':
+      - gem: 'serverspec'
+      - gem: 'hiera-puppet-helper'
+      - gem: 'beaker'
+      - gem: 'beaker-rspec'
 
 Rakefile:
   requires:

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,6 +1,5 @@
 ---
 ".travis.yml":
-  use_litmus: true
   deploy_to_forge:
     enabled: false
   secure: ''
@@ -9,6 +8,25 @@
     - master
     - /^v\d/
   simplecov: true
+  use_litmus: true
+  litmus:
+    provision_list:
+    - ---travis_el
+    - travis_deb
+    - travis_el6
+    - travis_el7
+    - travis_el8
+    complex:
+    - collection:
+        puppet_collection:
+        - puppet6
+        provision_list:
+        - travis_ub_6
+    - collection:
+        puppet_collection:
+        - puppet5
+        provision_list:
+        - travis_ub_5
 
 appveyor.yml:
   delete: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,7 +1,6 @@
 ---
 ".travis.yml":
   use_litmus: true
-  beaker: true
   deploy_to_forge:
     enabled: false
   secure: ''
@@ -22,8 +21,6 @@ Gemfile:
     ':development':
       - gem: 'serverspec'
       - gem: 'hiera-puppet-helper'
-      - gem: 'beaker'
-      - gem: 'beaker-rspec'
 
 Rakefile:
   requires:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,28 @@ jobs:
   include:
     -
       before_script:
+      - "bundle exec rake 'litmus:provision_list[travis_ub_6]'"
+      - "bundle exec rake 'litmus:install_agent[puppet6]'"
+      - "bundle exec rake litmus:install_module"
+      bundler_args:
+      env: PLATFORMS=travis_ub_6_puppet6
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+    -
+      before_script:
+      - "bundle exec rake 'litmus:provision_list[travis_ub_5]'"
+      - "bundle exec rake 'litmus:install_agent[puppet5]'"
+      - "bundle exec rake litmus:install_module"
+      bundler_args:
+      env: PLATFORMS=travis_ub_5_puppet5
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+    -
+      before_script:
       - "bundle exec rake 'litmus:provision_list[travis_deb]'"
       - "bundle exec rake 'litmus:install_agent[puppet5]'"
       - "bundle exec rake litmus:install_module"
@@ -37,11 +59,33 @@ jobs:
       stage: acceptance
     -
       before_script:
-      - "bundle exec rake 'litmus:provision_list[travis_el]'"
+      - "bundle exec rake 'litmus:provision_list[travis_el6]'"
       - "bundle exec rake 'litmus:install_agent[puppet5]'"
       - "bundle exec rake litmus:install_module"
       bundler_args:
-      env: PLATFORMS=travis_el_puppet5
+      env: PLATFORMS=travis_el6_puppet5
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+    -
+      before_script:
+      - "bundle exec rake 'litmus:provision_list[travis_el7]'"
+      - "bundle exec rake 'litmus:install_agent[puppet5]'"
+      - "bundle exec rake litmus:install_module"
+      bundler_args:
+      env: PLATFORMS=travis_el7_puppet5
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+    -
+      before_script:
+      - "bundle exec rake 'litmus:provision_list[travis_el8]'"
+      - "bundle exec rake 'litmus:install_agent[puppet5]'"
+      - "bundle exec rake litmus:install_module"
+      bundler_args:
+      env: PLATFORMS=travis_el8_puppet5
       rvm: 2.5.7
       script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
       services: docker
@@ -59,11 +103,33 @@ jobs:
       stage: acceptance
     -
       before_script:
-      - "bundle exec rake 'litmus:provision_list[travis_el]'"
+      - "bundle exec rake 'litmus:provision_list[travis_el6]'"
       - "bundle exec rake 'litmus:install_agent[puppet6]'"
       - "bundle exec rake litmus:install_module"
       bundler_args:
-      env: PLATFORMS=travis_el_puppet6
+      env: PLATFORMS=travis_el6_puppet6
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+    -
+      before_script:
+      - "bundle exec rake 'litmus:provision_list[travis_el7]'"
+      - "bundle exec rake 'litmus:install_agent[puppet6]'"
+      - "bundle exec rake litmus:install_module"
+      bundler_args:
+      env: PLATFORMS=travis_el7_puppet6
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+    -
+      before_script:
+      - "bundle exec rake 'litmus:provision_list[travis_el8]'"
+      - "bundle exec rake 'litmus:install_agent[puppet6]'"
+      - "bundle exec rake litmus:install_module"
+      bundler_args:
+      env: PLATFORMS=travis_el8_puppet6
       rvm: 2.5.7
       script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
       services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,50 @@ jobs:
   fast_finish: true
   include:
     -
+      before_script:
+      - "bundle exec rake 'litmus:provision_list[travis_deb]'"
+      - "bundle exec rake 'litmus:install_agent[puppet5]'"
+      - "bundle exec rake litmus:install_module"
+      bundler_args:
+      env: PLATFORMS=travis_deb_puppet5
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+    -
+      before_script:
+      - "bundle exec rake 'litmus:provision_list[travis_el]'"
+      - "bundle exec rake 'litmus:install_agent[puppet5]'"
+      - "bundle exec rake litmus:install_module"
+      bundler_args:
+      env: PLATFORMS=travis_el_puppet5
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+    -
+      before_script:
+      - "bundle exec rake 'litmus:provision_list[travis_deb]'"
+      - "bundle exec rake 'litmus:install_agent[puppet6]'"
+      - "bundle exec rake litmus:install_module"
+      bundler_args:
+      env: PLATFORMS=travis_deb_puppet6
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+    -
+      before_script:
+      - "bundle exec rake 'litmus:provision_list[travis_el]'"
+      - "bundle exec rake 'litmus:install_agent[puppet6]'"
+      - "bundle exec rake litmus:install_module"
+      bundler_args:
+      env: PLATFORMS=travis_el_puppet6
+      rvm: 2.5.7
+      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
+      services: docker
+      stage: acceptance
+    -
       env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
       stage: static
     -
@@ -34,10 +78,6 @@ jobs:
     -
       env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
       rvm: 2.5.7
-      stage: spec
-    -
-      env: PUPPET_GEM_VERSION="~> 4.10" CHECK=parallel_spec
-      rvm: 2.4.5
       stage: spec
 branches:
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,10 @@ group :development do
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "serverspec",                                              require: false
+  gem "hiera-puppet-helper",                                     require: false
+  gem "beaker",                                                  require: false
+  gem "beaker-rspec",                                            require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Gemfile
+++ b/Gemfile
@@ -30,8 +30,6 @@ group :development do
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec",                                              require: false
   gem "hiera-puppet-helper",                                     require: false
-  gem "beaker",                                                  require: false
-  gem "beaker-rspec",                                            require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/manifests/envconfig.pp
+++ b/manifests/envconfig.pp
@@ -5,7 +5,7 @@ class sogo::envconfig {
     file { $sogo::envconfig_path:
       ensure       => 'present',
       content      => epp('sogo/sogo.envconfig.epp', { envconfig => $sogo::envconfig }),
-      validate_cmd => '/usr/bin/bash -n %',
+      validate_cmd => '/bin/bash -n %',
       notify       => Service[$sogo::service_name],
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -8,41 +8,57 @@
   "project_page": "https://github.com/Thor77/puppet-sogo",
   "issues_url": "https://github.com/Thor77/puppet-sogo/issues",
   "dependencies": [
-
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.10.0 < 7.0.0"
+    }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9",
+        "10"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "14.04",
+        "16.04",
+        "18.04",
+        "20.04"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "6",
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "6",
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "7"
+        "6",
+        "7",
+        "8"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
-    },
-    {
-      "name": "puppet/stdlib",
       "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],

--- a/provision.yaml
+++ b/provision.yaml
@@ -1,0 +1,13 @@
+---
+travis_deb:
+  provisioner: docker
+  images: ['litmusimage/debian:8', 'litmusimage/debian:9', 'litmusimage/debian:10']
+travis_el:
+  provisioner: docker
+  images: ['litmusimage/centos:6', 'litmusimage/centos:7', 'litmusimage/centos:8', 'litmusimage/scientificlinux:6', 'litmusimage/scientificlinux:7', 'litmusimage/oraclelinux:6', 'litmusimage/oraclelinux:7']
+travis_ol:
+  provisioner: docker
+  images: ['litmusimage/oraclelinux:6', 'litmusimage/oraclelinux:7']
+travis_ub:
+  provisioner: docker
+  images: ['litmusimage/ubuntu:14.04', 'litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04', 'litmusimage/ubuntu:20.04']

--- a/provision.yaml
+++ b/provision.yaml
@@ -2,12 +2,18 @@
 travis_deb:
   provisioner: docker
   images: ['litmusimage/debian:8', 'litmusimage/debian:9', 'litmusimage/debian:10']
-travis_el:
+travis_ub_5:
   provisioner: docker
-  images: ['litmusimage/centos:6', 'litmusimage/centos:7', 'litmusimage/centos:8', 'litmusimage/scientificlinux:6', 'litmusimage/scientificlinux:7', 'litmusimage/oraclelinux:6', 'litmusimage/oraclelinux:7']
-travis_ol:
-  provisioner: docker
-  images: ['litmusimage/oraclelinux:6', 'litmusimage/oraclelinux:7']
-travis_ub:
+  images: ['litmusimage/ubuntu:14.04', 'litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04']
+travis_ub_6:
   provisioner: docker
   images: ['litmusimage/ubuntu:14.04', 'litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04', 'litmusimage/ubuntu:20.04']
+travis_el6:
+  provisioner: docker
+  images: ['litmusimage/centos:6', 'litmusimage/oraclelinux:6', 'litmusimage/scientificlinux:6']
+travis_el7:
+  provisioner: docker
+  images: ['litmusimage/centos:7', 'litmusimage/oraclelinux:7', 'litmusimage/scientificlinux:7']
+travis_el8:
+  provisioner: docker
+  images: ['litmusimage/centos:8']

--- a/spec/acceptance/sogo_spec.rb
+++ b/spec/acceptance/sogo_spec.rb
@@ -66,6 +66,10 @@ describe '::sogo' do
         it { is_expected.to be_file }
         its(:content) { is_expected.to match %r{^PREFORK=3$} }
       end
+
+      describe port(20_000) do
+        it { is_expected.to be_listening }
+      end
     end
   end
 
@@ -82,6 +86,10 @@ describe '::sogo' do
       describe file('/etc/default/sogo') do
         it { is_expected.to be_file }
         its(:content) { is_expected.to match %r{^PREFORK=3$} }
+      end
+
+      describe port(20_000) do
+        it { is_expected.to be_listening }
       end
     end
   end

--- a/spec/acceptance/sogo_spec.rb
+++ b/spec/acceptance/sogo_spec.rb
@@ -14,7 +14,7 @@ describe '::sogo' do
             line => 'PIDFile=/var/run/sogo/sogo.pid',
             notify => Service['sogod'],
           }
-	}
+        }
       }
       'Debian': {
 	$extra_packages = ['sope4.9-gdl1-postgresql']

--- a/spec/acceptance/sogo_spec.rb
+++ b/spec/acceptance/sogo_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper_acceptance'
+
+describe '::sogo' do
+  pp = <<-PUPPETCODE
+    $database = 'postgresql://sogo@127.0.0.1/sogo'
+
+    case $facts['os']['family'] {
+      'RedHat': {
+        $extra_packages = ['sope49-gdl1-postgresql']
+        if versioncmp($facts['os']['release']['major'], '7') >= 0 {
+          file_line { 'fix_sogo_systemd_unit':
+            ensure => 'absent',
+            path => '/usr/lib/systemd/system/sogod.service',
+            line => 'PIDFile=/var/run/sogo/sogo.pid',
+            notify => Service['sogod'],
+          }
+	}
+      }
+      'Debian': {
+	$extra_packages = ['sope4.9-gdl1-postgresql']
+      }
+      default: { warning('Only prepared for Debian and RedHat based systems') }
+    }
+
+    class { 'sogo':
+      extra_packages => $extra_packages,
+      config => {
+          'SOGoSieveScriptsEnabled' => 'YES',
+          'SOGoMailCustomFromEnabled' => 'YES',
+          'SOGoUserSources' => {
+              'type' => 'sql',
+              'id' => 'directory',
+              'viewURL' => "${database}/sogo_view",
+          },
+      },
+      envconfig => {
+          'PREFORK' => 3,
+      },
+    }
+  PUPPETCODE
+
+  context 'on all systems default parameters' do
+    apply_manifest(pp)
+
+    describe package('sogo') do
+      it { is_expected.to be_installed }
+    end
+
+    describe file('/etc/sogo/sogo.conf') do
+      it { is_expected.to be_file }
+      its(:content) { is_expected.to match %r{SOGoUserSources = \(\n    \{\n      type = sql;} }
+    end
+  end
+
+  context 'on redhat/oracle systems' do
+    if os[:family] =~ %r{redhat|oracle}
+
+      idempotent_apply(pp)
+
+      describe service('sogod') do
+        it { is_expected.to be_enabled }
+        it { is_expected.to be_running }
+      end
+
+      describe file('/etc/sysconfig/sogo') do
+        it { is_expected.to be_file }
+        its(:content) { is_expected.to match %r{^PREFORK=3$} }
+      end
+    end
+  end
+
+  context 'on debian/ubuntu systems' do
+    if os[:family] =~ %r{debian|ubuntu}
+
+      idempotent_apply(pp)
+
+      describe service('sogo') do
+        it { is_expected.to be_enabled }
+        it { is_expected.to be_running }
+      end
+
+      describe file('/etc/default/sogo') do
+        it { is_expected.to be_file }
+        its(:content) { is_expected.to match %r{^PREFORK=3$} }
+      end
+    end
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'puppet_litmus'
+require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
+include PuppetLitmus
+include PrepareSogoEnvironment
+
+PuppetLitmus.configure!
+
+PrepareSogoEnvironment.install_requirements

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class LitmusHelper
+  include PuppetLitmus
+end
+
+module PrepareSogoEnvironment
+  def install_requirements
+    LitmusHelper.run_shell('puppet module install puppetlabs/apt')
+
+    pre_pp = <<-PUPPETCODE
+      if $::osfamily == 'Debian' {
+        package { 'lsb-release':
+          ensure   => 'installed'
+        }
+      }
+    PUPPETCODE
+
+    pp = <<-PUPPETCODE
+      case $facts['os']['family'] {
+        'RedHat': {
+          if $facts['os']['name'] == 'OracleLinux' {
+            if versioncmp($facts['os']['release']['major'], '7') >= 0 {
+              package { "oracle-epel-release-el${facts['os']['release']['major']}":
+                ensure   => 'installed'
+              }
+            }
+          } else {
+            package { 'epel-release':
+              ensure   => 'installed'
+            }
+          }
+          yumrepo { "sogo-rhel-${facts['os']['release']['major']}":
+            baseurl => "https://packages.inverse.ca/SOGo/nightly/5/rhel/${facts['os']['release']['major']}/\\$basearch",
+            gpgkey => 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb022c48d3d6373d7fc256a8ccb2d3a2aa0030e2c',
+            gpgcheck => true
+          }
+        }
+        'Debian': {
+          include apt
+          $osname_lower = downcase($facts['os']['name'])
+          # Dirty workaround for https://sogo.nu/bugs/view.php?id=4776
+          file { '/usr/share/doc/sogo/':
+            ensure => directory
+          }->
+          file { '/usr/share/doc/sogo/empty.sh':
+            ensure => present,
+            content => '# keepme - https://sogo.nu/bugs/view.php?id=4776'
+          }
+          apt::source { 'sogo':
+            location => "http://packages.inverse.ca/SOGo/nightly/5/${osname_lower}/",
+            repos => "$lsbdistcodename",
+            key => {
+              id => 'FE9E84327B18FF82B0378B6719CDA6A9810273C4',
+              server => 'keyserver.ubuntu.com',
+            }
+          }
+        }
+        default: { warning('Only prepared for Debian and RedHat based systems') }
+      }
+    PUPPETCODE
+
+    LitmusHelper.apply_manifest(pre_pp)
+    LitmusHelper.apply_manifest(pp)
+  end
+end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -33,7 +33,7 @@ module PrepareSogoEnvironment
           yumrepo { "sogo-rhel-${facts['os']['release']['major']}":
             baseurl => "https://packages.inverse.ca/SOGo/nightly/5/rhel/${facts['os']['release']['major']}/\\$basearch",
             gpgkey => 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb022c48d3d6373d7fc256a8ccb2d3a2aa0030e2c',
-            gpgcheck => true
+            gpgcheck => false
           }
         }
         'Debian': {


### PR DESCRIPTION
Hi,

this PR adds litmus acceptance tests on

- ubuntu 14.04, 16.04, 18.04 and 20.04
- debian 8, 9, 10
- centos 6, 7, 8
- scientific 6, 7
- oracle 6, 7

for Puppet 5 + 6

Unfortunately we can't test with Puppet 4 using litmus - so this change would also drop the unit tests for Puppet 4. Due to the fact htat Puppet 4 is already end of life I really wouldn't invest much time here for creating tests. What do you think?